### PR TITLE
Explicit credentials not working

### DIFF
--- a/Public/Connect-AutomateAPI.ps1
+++ b/Public/Connect-AutomateAPI.ps1
@@ -111,6 +111,10 @@ Connect-AutomateAPI -Quiet
         Do {
             $AutomateAPIURI = ('https://' + $Server + '/cwa/api/v1')
             If (!$Quiet) {
+                If($Credential)
+                {
+                    $testCredentials=$Credential
+                }
                 If (!$Credential -and ($Force -or !$AuthorizationToken)) {
                     If (!$Force -and $Script:CWACredentials) {
                         $testCredentials = $Script:CWACredentials

--- a/Public/Connect-ControlAPI.ps1
+++ b/Public/Connect-ControlAPI.ps1
@@ -47,21 +47,15 @@ function Connect-ControlAPI {
 #        [Parameter(ParameterSetName = 'credential', Mandatory = $False)]
 #        [String]$TwoFactorToken,
 
-        [Parameter(ParameterSetName = 'credential', Mandatory = $False)]
-        [Switch]$Force,
+        [Parameter(ParameterSetName = 'refresh', Mandatory = $False)]
+        [Switch]$Refresh,
 
-        [Parameter(ParameterSetName = 'verify', Mandatory = $False)]
+        [Parameter(ParameterSetName = 'verify', Mandatory = $True)]
         [Switch]$Verify,
 
         [Parameter(ParameterSetName = 'credential', Mandatory = $False)]
         [Parameter(ParameterSetName = 'apikey', Mandatory = $False)]
-        [Switch]$SkipCheck,
-
-        [Parameter(ParameterSetName = 'credential', Mandatory = $False)]
-        [Parameter(ParameterSetName = 'refresh', Mandatory = $False)]
-        [Parameter(ParameterSetName = 'apikey', Mandatory = $False)]
-        [Parameter(ParameterSetName = 'verify', Mandatory = $False)]
-        [Switch]$Quiet
+        [Switch]$SkipCheck
 
     )
     
@@ -70,7 +64,7 @@ function Connect-ControlAPI {
 #        if ($TwoFactorToken -match '.+') {$Force=$True}
         $TwoFactorNeeded=$False
 
-        If (!$Quiet -and !$Verify) {
+        If (!$Verify) {
             While (!($Server -match '.+')) {
                 $Server = Read-Host -Prompt "Please enter your Control Server address, the full URL. IE https://control.rancorthebeast.com:8040" 
             }
@@ -119,6 +113,10 @@ function Connect-ControlAPI {
             Do {
                 $ControlAPITestURI = ($Server + '/Services/PageService.ashx/GetHostSessionInfo')
                 If (!$Quiet) {
+                    If($Credential)
+                    {
+                        $testCredentials=$Credential
+                    }
                     If (!$Credential -and !$Verify) {
                         If (!$testCredentials -or $Force) {
                             Write-Debug "No Credentials were provided and no existing Token was found, or -Force was specified"


### PR DESCRIPTION
Fixed issue where explicit credentials would not work against either Control or Automate. Also changed parameter set behavior to require -Refresh switch to force a refresh instead of that being the default behavior