### PR TITLE
Create Start-ControlRemoteSupport.ps1

### DIFF
--- a/Public/Connect-ControlSession.ps1
+++ b/Public/Connect-ControlSession.ps1
@@ -1,4 +1,4 @@
-function Start-ControlRemoteSupport {
+function Connect-ControlSession {
     <#
     .SYNOPSIS
         Will open a ConnectWise Control Remote Support session against a given machine.
@@ -10,7 +10,7 @@ function Start-ControlRemoteSupport {
     .PARAMETER ComputerID
         The Automate ComputerID to connect to
     .PARAMETER ID
-        Taken from the Pipeline, IE Get-AutomateComputer -ComputerID 5 | Start-ControlRemoteSupport
+        Taken from the Pipeline, IE Get-AutomateComputer -ComputerID 5 | Connect-ControlSession
     .PARAMETER ComputerObjects
         Used for Pipeline input from Get-AutomateComputer
     .OUTPUTS
@@ -22,11 +22,11 @@ function Start-ControlRemoteSupport {
         Purpose/Change: Initial script development
 
     .EXAMPLE
-        Start-ControlRemoteSupport -ComputerName TestComputer
+        Connect-ControlSession -ComputerName TestComputer
     .EXAMPLE
-        Start-ControlRemoteSupport -ComputerId 123
+        Connect-ControlSession -ComputerId 123
     .EXAMPLE
-        Get-AutomateComputer -ComputerID 5 | Start-ControlRemoteSupport
+        Get-AutomateComputer -ComputerID 5 | Connect-ControlSession
     #>
     [CmdletBinding(DefaultParameterSetName = 'Name')]
     param
@@ -71,4 +71,4 @@ function Start-ControlRemoteSupport {
         } #End ForEach
     } #End Process
 
-} #End Start-ControlRemoteSupport
+} #End Connect-ControlSession

--- a/Public/Start-ControlRemoteSupport.ps1
+++ b/Public/Start-ControlRemoteSupport.ps1
@@ -28,7 +28,7 @@ function Start-ControlRemoteSupport {
     .EXAMPLE
         Get-AutomateComputer -ComputerID 5 | Start-ControlRemoteSupport
     #>
-    [CmdletBinding(DefaultParameterSetName = 'ID')]
+    [CmdletBinding(DefaultParameterSetName = 'Name')]
     param
     (
         [Parameter(ParameterSetName = 'Name', Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName=$False)]
@@ -64,7 +64,8 @@ function Start-ControlRemoteSupport {
         }
 
         ForEach ($Computer in $ComputerObjects) {
-            Start-Process "$((Get-AutomateComputer -ComputerID $Computer.ID | Get-AutomateControlInfo).LaunchURL)"
+            $ControlInfo = Get-AutomateControlInfo -ComputerID $Computer.ID
+            $ControlInfo.LaunchSession()
         } #End ForEach
     } #End Process
 

--- a/Public/Start-ControlRemoteSupport.ps1
+++ b/Public/Start-ControlRemoteSupport.ps1
@@ -1,0 +1,71 @@
+function Start-ControlRemoteSupport {
+    <#
+    .SYNOPSIS
+        Will open a ConnectWise Control Remote Support session against a given machine.
+    .DESCRIPTION
+        Will open a ConnectWise Control Remote Support session against a given machine.
+
+    .PARAMETER ComputerName
+        The Automate computer name to connect to
+    .PARAMETER ComputerID
+        The Automate ComputerID to connect to
+    .PARAMETER ID
+        Taken from the Pipeline, IE Get-AutomateComputer -ComputerID 5 | Start-ControlRemoteSupport
+    .PARAMETER ComputerObjects
+        Used for Pipeline input from Get-AutomateComputer
+    .OUTPUTS
+        None (opens a Connect Control Remote Support session URL, via a URL to the default browser)
+    .NOTES
+        Version:        1.0
+        Author:         Jason Rush
+        Creation Date:  2019-10-15
+        Purpose/Change: Initial script development
+
+    .EXAMPLE
+        Start-ControlRemoteSupport -ComputerName TestComputer
+    .EXAMPLE
+        Start-ControlRemoteSupport -ComputerId 123
+    .EXAMPLE
+        Get-AutomateComputer -ComputerID 5 | Start-ControlRemoteSupport
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'ID')]
+    param
+    (
+        [Parameter(ParameterSetName = 'Name', Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName=$False)]
+        [string[]]$ComputerName,
+
+        [Parameter(ParameterSetName = 'ID', Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName=$False)]
+        [int16[]]$ComputerID,
+
+        [Parameter(ParameterSetName = 'pipeline', ValueFromPipelineByPropertyName=$true, Mandatory = $True)]
+        [int16[]]$ID,
+
+        [Parameter(ParameterSetName = 'pipeline', ValueFromPipeline = $true, Mandatory = $True)]
+        $ComputerObjects
+        
+    )
+
+    Process {
+        #If not pipeline mode, build ComputerObjects
+        If ( ($PSCmdlet.ParameterSetName -eq 'ID') -or ($PSCmdlet.ParameterSetName -eq 'Name') ) {
+            $ComputerObjects = @()
+        }
+
+        If ($PSCmdlet.ParameterSetName -eq 'ID') {
+            ForEach ($ComputerIDSingle in $ComputerID) {
+                $ComputerObjects += (Get-AutomateComputer -ComputerID $ComputerIDSingle)
+            }
+        }
+
+        If ($PSCmdlet.ParameterSetName -eq 'Name') {
+            ForEach ($ComputerNameSingle in $ComputerName) {
+                $ComputerObjects += (Get-AutomateComputer -ComputerName $ComputerNameSingle)
+            }
+        }
+
+        ForEach ($Computer in $ComputerObjects) {
+            Start-Process "$((Get-AutomateComputer -ComputerID $Computer.ID | Get-AutomateControlInfo).LaunchURL)"
+        } #End ForEach
+    } #End Process
+
+} #End Start-ControlRemoteSupport

--- a/Public/Start-ControlRemoteSupport.ps1
+++ b/Public/Start-ControlRemoteSupport.ps1
@@ -64,8 +64,10 @@ function Start-ControlRemoteSupport {
         }
 
         ForEach ($Computer in $ComputerObjects) {
-            $ControlInfo = Get-AutomateControlInfo -ComputerID $Computer.ID
-            $ControlInfo.LaunchSession()
+            try {
+                $(Get-AutomateControlInfo $Computer.ID).LaunchSession()
+            }
+            catch {}
         } #End ForEach
     } #End Process
 


### PR DESCRIPTION
Created Start-ControlRemoteSupport.ps1, verified initial functionality. When run, will open the LaunchURL in the default browser, which then launches a Control Remote Support session to the given device. I'm not sure if there may be a better way to launch these sessions from the URLs, but one of the big conveniences of this setup for me is being able to quickly/easily connect to a remote device without the Automate thick client, or logging into the web client. This is essentially a shortcut to doing the following (which is very cumbersome for most people/techs to remember, let alone typing regularly:

`Start-Process "$((Get-AutomateComputer -ComputerID 1234 | Get-AutomateControlInfo).LaunchURL)"`

Code run to test/verify functionality:

```
Import-Module .\Documents\WindowsPowerShell\Modules\AutomateAPI\AutomateAPI.psm1
Connect-AutomateAPI -Server asdf.hostedrmm.com

Start-ControlRemoteSupport -ComputerName buildroom
pause
Start-ControlRemoteSupport -ComputerId 1234
pause
Get-AutomateComputer -ComputerID 1234 | Start-ControlRemoteSupport
```