### PR TITLE
ConnectWise Automate v2020.11 requires a registered clientId. Added Support for ClientIDs

### DIFF
--- a/Docs/Connect-AutomateAPI.md
+++ b/Docs/Connect-AutomateAPI.md
@@ -20,7 +20,7 @@ Connect-AutomateAPI [-Server <String>] [-AuthorizationToken <String>] [-SkipChec
 
 ### credential
 ```
-Connect-AutomateAPI [-Credential <PSCredential>] [-Server <String>] [-SkipCheck] [-TwoFactorToken <String>]
+Connect-AutomateAPI [-Credential <PSCredential>] [-Server <String>] -apiClientID <String> [-SkipCheck] [-TwoFactorToken <String>]
  [-Force] [-Quiet] [<CommonParameters>]
 ```
 
@@ -36,7 +36,7 @@ Connects to the Automate API and returns a bearer token which when passed with e
 
 ### EXAMPLE 1
 ```
-Connect-AutomateAPI -Server "rancor.hostedrmm.com" -Credentials $CredentialObject -TwoFactorToken "999999"
+Connect-AutomateAPI -Server "rancor.hostedrmm.com" -Credentials $CredentialObject -TwoFactorToken "999999" -apiClientID '123123123-1234-1234-1234-123123123123'
 ```
 
 ### EXAMPLE 2
@@ -73,6 +73,21 @@ Aliases:
 Required: False
 Position: Named
 Default value: $Script:CWAServer
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -apiClientID
+Your Registered clientID obtained here: https://developer.connectwise.com/ClientID
+
+```yaml
+Type: String
+Parameter Sets: (credential)
+Aliases:
+
+Required: True
+Position: Named
+Default value: none
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -189,4 +204,7 @@ Author:         Darren White
 Purpose/Change: Credential and 2FA prompting is only if needed.
 Supports Token Refresh.
 
+Update Date:    2020-11-19
+Author:         Brandon Fahnestock
+Purpose/Change: ConnectWise Automate v2020.11 requires a registered ClientID for API access. Added Support for ClientIDs 
 ## RELATED LINKS

--- a/Private/Invoke-AutomateAPIMaster.ps1
+++ b/Private/Invoke-AutomateAPIMaster.ps1
@@ -16,6 +16,10 @@ function Invoke-AutomateAPIMaster {
 
         Update Date:    2020-08-01
         Purpose/Change: Change to use CWAIsConnected script variable to track connection state
+      
+        Update Date:    2020-11-19
+        Author:         Brandon Fahnestock
+        Purpose/Change: ConnectWise Automate v2020.11 requires a registered ClientID for API access. Added Support for ClientIDs 
     .EXAMPLE
         Invoke-AutomateAPIMaster -Arguments $Arguments
     #>
@@ -59,6 +63,8 @@ function Invoke-AutomateAPIMaster {
         If($Arguments.URI -notmatch '^https?://') {
           $Arguments.URI = ($Script:CWAServer + $Arguments.URI)
         }
+        #Add required CWA ClientID to API request
+        $Arguments.Headers += @{'clientID' = "$Script:CWAClientID"}
 
         # Issue request
         Try {

--- a/Public/Connect-AutomateAPI.ps1
+++ b/Public/Connect-AutomateAPI.ps1
@@ -35,8 +35,12 @@ Purpose/Change: Credential and 2FA prompting is only if needed. Supports Token R
 Update Date:    2020-08-01
 Purpose/Change: Change to use CWAIsConnected script variable to track connection state
 
+Update Date:    2020-11-19
+Author:         Brandon Fahnestock
+Purpose/Change: ConnectWise Automate v2020.11 requires a registered ClientID for API access. Added Support for ClientIDs 
+
 .EXAMPLE
-Connect-AutomateAPI -Server "rancor.hostedrmm.com" -Credentials $CredentialObject -TwoFactorToken "999999"
+Connect-AutomateAPI -Server "rancor.hostedrmm.com" -Credentials $CredentialObject -TwoFactorToken "999999" -apiClientID '123123123-1234-1234-1234-123123123123'
 
 .EXAMPLE
 Connect-AutomateAPI -Quiet
@@ -45,6 +49,9 @@ Connect-AutomateAPI -Quiet
     param (
         [Parameter(ParameterSetName = 'credential', Mandatory = $False)]
         [System.Management.Automation.PSCredential]$Credential,
+
+        [Parameter(ParameterSetName = 'credential', Mandatory = $True)]
+        [String]$apiClientID,
 
         [Parameter(ParameterSetName = 'credential', Mandatory = $False)]
         [Parameter(ParameterSetName = 'refresh', Mandatory = $False)]
@@ -86,6 +93,8 @@ Connect-AutomateAPI -Quiet
         $Server = $Server -replace '^https?://','' -replace '/[^\/]*$',''
         $AuthorizationToken = $AuthorizationToken -replace 'Bearer ',''
         $Script:CWAIsConnected=$False
+        $Script:CWAClientID = $apiClientID
+
     } #End Begin
     
     Process {


### PR DESCRIPTION
Connect-AutomateAP.ps1: Added apiClientID as a required parameter

Invoke-AutomateAPIMaster.ps1: Added apiClientID to $Arguments.Headers