### PR TITLE
Added support for client id and pester tests

### DIFF
--- a/AutomateAPI.tests.ps1
+++ b/AutomateAPI.tests.ps1
@@ -1,0 +1,12 @@
+#using Pester to run tests
+Import-Module "$PSScriptRoot\\AutomateAPI.psm1" -Force
+
+Describe AutomateAPI {
+    It "Connects to the Automate API" {
+        $result = Connect-AutomateAPI
+        $result | Should -be $null
+    }
+    It "Automate API returns a list of computers" {
+        (Get-AutomateComputer -AllComputers).Count | Should -BeGreaterThan 0
+    }
+}


### PR DESCRIPTION
Added support for ClientID now required by Automate patch 2020.11.
Built and tested on patch 2020.11.
Needs testing on previous Automate versions.
Added Pester tests to test connection and getting computers via the API.