### PR TITLE
Pester Tests, Automated Credentials, Param Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+credentials.json

--- a/AutomateAPI.psm1
+++ b/AutomateAPI.psm1
@@ -11,21 +11,26 @@ $Private = @( Get-ChildItem -Recurse -Path "$PSScriptRoot\Private\" -File -Filte
 
 $Script:LTPoShURI='https://raw.githubusercontent.com/LabtechConsulting/LabTech-Powershell-Module/master/LabTech.psm1'
 
-#Ignore SSL errors
-If ($Null -eq ([System.Management.Automation.PSTypeName]'TrustAllCertsPolicy').Type) {
-    Add-Type -Debug:$False @"
-        using System.Net;
-        using System.Security.Cryptography.X509Certificates;
-        public class TrustAllCertsPolicy : ICertificatePolicy {
-            public bool CheckValidationResult(
-                ServicePoint srvPoint, X509Certificate certificate,
-                WebRequest request, int certificateProblem) {
-                return true;
+#check PS version for this, PS 6 and above use -SkipCertificateCheck for Invoke-RestMethod
+if ($PSVersionTable.PSVersion.Major -lt 6)
+{
+    #Ignore SSL errors
+    If ($Null -eq ([System.Management.Automation.PSTypeName]'TrustAllCertsPolicy').Type) {
+        Add-Type -Debug:$False @"
+            using System.Net;
+            using System.Security.Cryptography.X509Certificates;
+            public class TrustAllCertsPolicy : ICertificatePolicy {
+                public bool CheckValidationResult(
+                    ServicePoint srvPoint, X509Certificate certificate,
+                    WebRequest request, int certificateProblem) {
+                    return true;
+                }
             }
-        }
 "@
+    }
+    [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
 }
-[System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
+
 
 #Enable TLS, TLS1.1, TLS1.2 in this session if they are available
 IF([Net.SecurityProtocolType]::Tls) {[Net.ServicePointManager]::SecurityProtocol=[Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls}

--- a/AutomateAPI.tests.ps1
+++ b/AutomateAPI.tests.ps1
@@ -1,0 +1,19 @@
+#using Pester to run tests
+Import-Module "$PSScriptRoot\\AutomateAPI.psm1" -Force
+
+Describe AutomateAPI {
+    It "Connects to the Automate API" {
+        $result = Connect-AutomateAPI -Debug
+        $result | Should -be $null
+    }
+    # It "Connects to the Control API" {
+    #     $result = Connect-ControlAPI -Debug
+    #     $result | Should -be $null
+    # }
+    It "Automate API returns a list of computers" {
+        (Get-AutomateComputer).Count | Should -BeGreaterThan 0
+    }
+    # It "Control API returns a list of sessions" {
+    #     (Get-ControlSessions).Count | Should -BeGreaterThan 0
+    # }
+}

--- a/AutomateAPI.tests.ps1
+++ b/AutomateAPI.tests.ps1
@@ -17,7 +17,8 @@ Describe AutomateAPI {
         Write-Output $creds.Automate
         $password = ConvertTo-SecureString $creds.Automate.password -AsPlainText -Force
         $credentials = New-Object System.Management.Automation.PSCredential($creds.Automate.user, $password)
-        $result = Connect-AutomateAPI -Server $creds.Automate.server -Credentials $credentials -apiClientID $creds.Automate.clientid
+        $result = Connect-AutomateAPI -Server $creds.Automate.server -Credentials $credentials `
+                    -apiClientID $creds.Automate.clientid
         $result | Should -be $null
     }
 

--- a/AutomateAPI.tests.ps1
+++ b/AutomateAPI.tests.ps1
@@ -1,19 +1,38 @@
 #using Pester to run tests
+#Remove module from memory
+Get-Module AutomateAPI | Remove-Module -Force
 Import-Module "$PSScriptRoot\\AutomateAPI.psm1" -Force
-
+#Get credentials $creds is available in every test
+#Copy credentials.example.json to a new file credentials.json
+$creds = Get-Content "$PSScriptRoot\\credentials.json" | Out-String | ConvertFrom-Json
 Describe AutomateAPI {
+    It "AutomateAPI is valid PowerShell code" {
+        $psFile = Get-Content -Path "$PSScriptRoot\AutomateAPI.psm1" -ErrorAction Stop
+        $errors = $null
+        $null = [System.Management.Automation.PSParser]::Tokenize($psFile, [ref]$errors)
+        $errors.Count | Should -Be 0
+    }
+
     It "Connects to the Automate API" {
-        $result = Connect-AutomateAPI -Debug
+        Write-Output $creds.Automate
+        $password = ConvertTo-SecureString $creds.Automate.password -AsPlainText -Force
+        $credentials = New-Object System.Management.Automation.PSCredential($creds.Automate.user, $password)
+        $result = Connect-AutomateAPI -Server $creds.Automate.server -Credentials $credentials -apiClientID $creds.Automate.clientid
         $result | Should -be $null
     }
-    # It "Connects to the Control API" {
-    #     $result = Connect-ControlAPI -Debug
-    #     $result | Should -be $null
-    # }
+
     It "Automate API returns a list of computers" {
         (Get-AutomateComputer).Count | Should -BeGreaterThan 0
     }
-    # It "Control API returns a list of sessions" {
-    #     (Get-ControlSessions).Count | Should -BeGreaterThan 0
-    # }
+    
+    It "Connects to the Control API" {
+        $password = ConvertTo-SecureString $creds.Control.password -AsPlainText -Force
+        $credentials = New-Object System.Management.Automation.PSCredential($creds.Control.user, $password)
+        $result = Connect-ControlAPI -Server $creds.Control.server -Credentials $credentials
+        $result | Should -be $null
+    }
+    
+    It "Control API returns a list of sessions" {
+        (Get-ControlSessions).Count | Should -BeGreaterThan 0
+    }
 }

--- a/Public/Connect-AutomateAPI.ps1
+++ b/Public/Connect-AutomateAPI.ps1
@@ -48,7 +48,7 @@ Connect-AutomateAPI -Quiet
     [CmdletBinding(DefaultParameterSetName = 'refresh')]
     param (
         [Parameter(ParameterSetName = 'credential', Mandatory = $False)]
-        [System.Management.Automation.PSCredential]$Credential,
+        [System.Management.Automation.PSCredential]$Credentials,
 
         [Parameter(ParameterSetName = 'credential', Mandatory = $False)]
         [Parameter(ParameterSetName = 'refresh', Mandatory = $False)]
@@ -110,9 +110,9 @@ Connect-AutomateAPI -Quiet
         $AutomateAPIURI = ('https://' + $Server + '/cwa/api/v1')
         If ($SkipCheck) {
             $Script:CWAServer = ("https://" + $Server)
-            If ($Credential) {
-                Write-Debug "Setting Credentials to $($Credential.UserName)"
-                $Script:CWACredentials = $Credential
+            If ($Credentials) {
+                Write-Debug "Setting Credentials to $($Credentials.UserName)"
+                $Script:CWACredentials = $Credentials
             }
             If ($AuthorizationToken) {
                 #Build the token
@@ -148,14 +148,14 @@ Connect-AutomateAPI -Quiet
         }
 
         Do {
-            $testCredentials=$Credential
+            $testCredentials=$Credentials
             If (!$Quiet) {
-                If (!$Credential -and ($Force -or !$AuthorizationToken)) {
+                If (!$Credentials -and ($Force -or !$AuthorizationToken)) {
                     If ($Force -or !$Script:CWACredentials) {
                         $Username = Read-Host -Prompt "Please enter your Automate Username"
                         $Password = Read-Host -Prompt "Please enter your Automate Password" -AsSecureString
-                        $Credential = New-Object System.Management.Automation.PSCredential ($Username, $Password)
-                        $testCredentials=$Credential
+                        $Credentials = New-Object System.Management.Automation.PSCredential ($Username, $Password)
+                        $testCredentials=$Credentials
                     }
                 }
                 If ($TwoFactorNeeded -eq $True -and $TwoFactorToken -match '') {
@@ -215,7 +215,7 @@ Connect-AutomateAPI -Quiet
                 If ($testCredentials) {
                     Remove-Variable CWACredentials -Scope Script -ErrorAction 0
                 }
-                If ($Credential) {
+                If ($Credentials) {
                     Throw "Attempt to authenticate to the Automate API has failed with error $_.Exception.Message"
                     Return
                 }
@@ -229,7 +229,7 @@ Connect-AutomateAPI -Quiet
             }
         } Until ($Quiet -or ![string]::IsNullOrEmpty($AuthorizationToken) -or 
                 ($PSCmdlet.ParameterSetName -eq 'verify' -and !$AuthorizationToken) -or
-                ($TwoFactorNeeded -ne $True -and $Credential) -or 
+                ($TwoFactorNeeded -ne $True -and $Credentials) -or 
                 ($TwoFactorNeeded -eq $True -and $TwoFactorToken -ne '')
             )
     } #End Process
@@ -259,8 +259,8 @@ Connect-AutomateAPI -Quiet
             $Script:CWAServer = ("https://" + $Server)
             $Script:CWAToken = $AutomateToken
             $Script:CWAIsConnected=$True
-            If ($Credential) {
-                $Script:CWACredentials = $Credential
+            If ($Credentials) {
+                $Script:CWACredentials = $Credentials
             }
             If ($apiClientID) {
                 $Script:CWAClientID = $apiClientID

--- a/Public/Connect-AutomateAPI.ps1
+++ b/Public/Connect-AutomateAPI.ps1
@@ -6,7 +6,7 @@ Connect to the Automate API.
 Connects to the Automate API and returns a bearer token which when passed with each requests grants up to an hours worth of access.
 .PARAMETER Server
 The address to your Automate Server. Example 'rancor.hostedrmm.com'
-.PARAMETER Credentials
+.PARAMETER Credential
 Takes a standard powershell credential object, this can be built with $CredentialsToPass = Get-Credential, then pass $CredentialsToPass
 .PARAMETER TwoFactorToken
 Takes a string that represents the 2FA number
@@ -40,7 +40,7 @@ Author:         Brandon Fahnestock
 Purpose/Change: ConnectWise Automate v2020.11 requires a registered ClientID for API access. Added Support for ClientIDs 
 
 .EXAMPLE
-Connect-AutomateAPI -Server "rancor.hostedrmm.com" -Credentials $CredentialObject -TwoFactorToken "999999" -apiClientID '123123123-1234-1234-1234-123123123123'
+Connect-AutomateAPI -Server "rancor.hostedrmm.com" -Credential $CredentialObject -TwoFactorToken "999999" -apiClientID '123123123-1234-1234-1234-123123123123'
 
 .EXAMPLE
 Connect-AutomateAPI -Quiet
@@ -48,7 +48,7 @@ Connect-AutomateAPI -Quiet
     [CmdletBinding(DefaultParameterSetName = 'refresh')]
     param (
         [Parameter(ParameterSetName = 'credential', Mandatory = $False)]
-        [System.Management.Automation.PSCredential]$Credentials,
+        [System.Management.Automation.PSCredential]$Credential,
 
         [Parameter(ParameterSetName = 'credential', Mandatory = $False)]
         [Parameter(ParameterSetName = 'refresh', Mandatory = $False)]
@@ -110,9 +110,9 @@ Connect-AutomateAPI -Quiet
         $AutomateAPIURI = ('https://' + $Server + '/cwa/api/v1')
         If ($SkipCheck) {
             $Script:CWAServer = ("https://" + $Server)
-            If ($Credentials) {
-                Write-Debug "Setting Credentials to $($Credentials.UserName)"
-                $Script:CWACredentials = $Credentials
+            If ($Credential) {
+                Write-Debug "Setting Credentials to $($Credential.UserName)"
+                $Script:CWACredentials = $Credential
             }
             If ($AuthorizationToken) {
                 #Build the token
@@ -148,14 +148,14 @@ Connect-AutomateAPI -Quiet
         }
 
         Do {
-            $testCredentials=$Credentials
+            $testCredential=$Credential
             If (!$Quiet) {
-                If (!$Credentials -and ($Force -or !$AuthorizationToken)) {
+                If (!$Credential -and ($Force -or !$AuthorizationToken)) {
                     If ($Force -or !$Script:CWACredentials) {
                         $Username = Read-Host -Prompt "Please enter your Automate Username"
                         $Password = Read-Host -Prompt "Please enter your Automate Password" -AsSecureString
-                        $Credentials = New-Object System.Management.Automation.PSCredential ($Username, $Password)
-                        $testCredentials=$Credentials
+                        $Credential = New-Object System.Management.Automation.PSCredential ($Username, $Password)
+                        $testCredential=$Credential
                     }
                 }
                 If ($TwoFactorNeeded -eq $True -and $TwoFactorToken -match '') {
@@ -163,14 +163,14 @@ Connect-AutomateAPI -Quiet
                 }
             }
 
-            If (!$AuthorizationToken -and !$testCredentials -and $Script:CWACredentials -and $Force -ne $True -and $PSCmdlet.ParameterSetName -ne 'verify') {
-                $testCredentials = $Script:CWACredentials
+            If (!$AuthorizationToken -and !$testCredential -and $Script:CWACredentials -and $Force -ne $True -and $PSCmdlet.ParameterSetName -ne 'verify') {
+                $testCredential = $Script:CWACredentials
             }
-            If ($testCredentials) {
+            If ($testCredential) {
                 #Build the headers for the Authentication
                 $PostBody = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
-                $PostBody.Add("username", $testCredentials.UserName)
-                $PostBody.Add("password", $testCredentials.GetNetworkCredential().Password)
+                $PostBody.Add("username", $testCredential.UserName)
+                $PostBody.Add("password", $testCredential.GetNetworkCredential().Password)
                 If (!([string]::IsNullOrEmpty($TwoFactorToken))) {
                     #Remove any spaces that were added
                     $TwoFactorToken = $TwoFactorToken -replace '\s', ''
@@ -212,10 +212,10 @@ Connect-AutomateAPI -Quiet
             }
             Catch {
                 Remove-Variable CWAToken,CWATokenKey -Scope Script -ErrorAction 0
-                If ($testCredentials) {
+                If ($testCredential) {
                     Remove-Variable CWACredentials -Scope Script -ErrorAction 0
                 }
-                If ($Credentials) {
+                If ($Credential) {
                     Throw "Attempt to authenticate to the Automate API has failed with error $_.Exception.Message"
                     Return
                 }
@@ -229,7 +229,7 @@ Connect-AutomateAPI -Quiet
             }
         } Until ($Quiet -or ![string]::IsNullOrEmpty($AuthorizationToken) -or 
                 ($PSCmdlet.ParameterSetName -eq 'verify' -and !$AuthorizationToken) -or
-                ($TwoFactorNeeded -ne $True -and $Credentials) -or 
+                ($TwoFactorNeeded -ne $True -and $Credential) -or 
                 ($TwoFactorNeeded -eq $True -and $TwoFactorToken -ne '')
             )
     } #End Process
@@ -259,8 +259,8 @@ Connect-AutomateAPI -Quiet
             $Script:CWAServer = ("https://" + $Server)
             $Script:CWAToken = $AutomateToken
             $Script:CWAIsConnected=$True
-            If ($Credentials) {
-                $Script:CWACredentials = $Credentials
+            If ($Credential) {
+                $Script:CWACredentials = $Credential
             }
             If ($apiClientID) {
                 $Script:CWAClientID = $apiClientID

--- a/Public/Connect-ControlAPI.ps1
+++ b/Public/Connect-ControlAPI.ps1
@@ -43,12 +43,12 @@ function Connect-ControlAPI {
     All values will be prompted for one by one:
     Connect-ControlAPI
     All values needed to Automatically create appropriate output
-    Connect-ControlAPI -Server "https://control.rancorthebeast.com:8040" -Credentials $CredentialsToPass
+    Connect-ControlAPI -Server "https://control.rancorthebeast.com:8040" -Credential $CredentialsToPass
     #>
     [CmdletBinding(DefaultParameterSetName = 'credential')]
     param (
         [Parameter(ParameterSetName = 'credential', Mandatory = $false)]
-        [System.Management.Automation.PSCredential]$Credentials,
+        [System.Management.Automation.PSCredential]$Credential,
 
         [Parameter(ParameterSetName = 'credential', Mandatory = $False)]
         [Parameter(ParameterSetName = 'apikey', Mandatory = $False)]
@@ -128,18 +128,18 @@ function Connect-ControlAPI {
             # Clear the ControlAPIKey variable
             Remove-Variable ControlAPIKey -Scope Script -ErrorAction 0
 
-            IF ($PSCmdlet.ParameterSetName -eq 'verify' -and $Null -eq $Credentials) {
+            IF ($PSCmdlet.ParameterSetName -eq 'verify' -and $Null -eq $Credential) {
                 # The Verify parameter will use the current ControlAPICredentials value.
-                $Credentials = $Script:ControlAPICredentials
+                $Credential = $Script:ControlAPICredentials
             }
             # Clear the ControlAPICredentials variable
             Remove-Variable ControlAPICredentials -Scope Script -ErrorAction 0
 
             # If we have not been given credentials, lets ask for them
-            If (!$Credentials -and !$Quiet) {
+            If (!$Credential -and !$Quiet) {
                 $Username = Read-Host -Prompt "Please enter your Control Username"
                 $Password = Read-Host -Prompt "Please enter your Control Password" -AsSecureString
-                $Credentials = New-Object System.Management.Automation.PSCredential ($Username, $Password)
+                $Credential = New-Object System.Management.Automation.PSCredential ($Username, $Password)
             }
 
             If ($SkipCheck) {
@@ -154,7 +154,7 @@ function Connect-ControlAPI {
                 'URI'         = $ControlAPITestURI
                 'Method'      = 'GET'
                 'ContentType' = 'application/json'
-                'Credential'  = $Credentials
+                'Credential'  = $Credential
             }
             Write-Debug "Submitting Request to $($RESTRequest.URI)"
 
@@ -175,7 +175,7 @@ function Connect-ControlAPI {
     }
 
     End {
-        If ($SkipCheck -and (!$Server -or ($PSCmdlet.ParameterSetName -eq 'apikey' -and ($Null -eq $APIKey)) -or ($PSCmdlet.ParameterSetName -eq 'credential' -and ($Null -eq $Credentials)))) {
+        If ($SkipCheck -and (!$Server -or ($PSCmdlet.ParameterSetName -eq 'apikey' -and ($Null -eq $APIKey)) -or ($PSCmdlet.ParameterSetName -eq 'credential' -and ($Null -eq $Credential)))) {
             # If Skipping Checks, validate required information exists and throw error if missing.
             Throw "SkipCheck failed because the Server, APIKey, or Credentials were not provided."
             If ($Quiet) {
@@ -194,9 +194,9 @@ function Connect-ControlAPI {
             }
         }
         Else {
-            If ($PSCmdlet.ParameterSetName -eq 'credential' -or ($PSCmdlet.ParameterSetName -eq 'verify' -and $Credentials)) {
+            If ($PSCmdlet.ParameterSetName -eq 'credential' -or ($PSCmdlet.ParameterSetName -eq 'verify' -and $Credential)) {
                 # Set the credentials at the script level
-                $Script:ControlAPICredentials = $Credentials
+                $Script:ControlAPICredentials = $Credential
             } 
             ElseIf ($PSCmdlet.ParameterSetName -eq 'apikey' -or ($PSCmdlet.ParameterSetName -eq 'verify' -and $APIKey)) {
                 $Script:ControlAPIKey = $APIKey

--- a/Public/Connect-ControlAPI.ps1
+++ b/Public/Connect-ControlAPI.ps1
@@ -155,10 +155,11 @@ function Connect-ControlAPI {
 
             # Invoke the REST Request
             Try {
-                $ControlAPITokenResult = Invoke-RestMethod @RESTRequest
+                $ControlAPITokenResult = Invoke-RestMethod @RESTRequest -SkipCertificateCheck
             }
             Catch {
                 # The authentication has failed, so remove the credentials from the script scope and throw an error
+                Write-Debug $_.Exception.Message
                 Throw "Unable to connect to Control. Server Address or Control Credentials are wrong. This module does not support 2FA for Control Users"
             }
             Write-Debug "Request Results: $($ControlAPITokenResult|ConvertTo-Json -Depth 5 -Compress)"

--- a/Public/Connect-ControlAPI.ps1
+++ b/Public/Connect-ControlAPI.ps1
@@ -48,7 +48,7 @@ function Connect-ControlAPI {
     [CmdletBinding(DefaultParameterSetName = 'credential')]
     param (
         [Parameter(ParameterSetName = 'credential', Mandatory = $false)]
-        [System.Management.Automation.PSCredential]$Credential,
+        [System.Management.Automation.PSCredential]$Credentials,
 
         [Parameter(ParameterSetName = 'credential', Mandatory = $False)]
         [Parameter(ParameterSetName = 'apikey', Mandatory = $False)]
@@ -128,18 +128,18 @@ function Connect-ControlAPI {
             # Clear the ControlAPIKey variable
             Remove-Variable ControlAPIKey -Scope Script -ErrorAction 0
 
-            IF ($PSCmdlet.ParameterSetName -eq 'verify' -and $Null -eq $Credential) {
+            IF ($PSCmdlet.ParameterSetName -eq 'verify' -and $Null -eq $Credentials) {
                 # The Verify parameter will use the current ControlAPICredentials value.
-                $Credential = $Script:ControlAPICredentials
+                $Credentials = $Script:ControlAPICredentials
             }
             # Clear the ControlAPICredentials variable
             Remove-Variable ControlAPICredentials -Scope Script -ErrorAction 0
 
             # If we have not been given credentials, lets ask for them
-            If (!$Credential -and !$Quiet) {
+            If (!$Credentials -and !$Quiet) {
                 $Username = Read-Host -Prompt "Please enter your Control Username"
                 $Password = Read-Host -Prompt "Please enter your Control Password" -AsSecureString
-                $Credential = New-Object System.Management.Automation.PSCredential ($Username, $Password)
+                $Credentials = New-Object System.Management.Automation.PSCredential ($Username, $Password)
             }
 
             If ($SkipCheck) {
@@ -154,7 +154,7 @@ function Connect-ControlAPI {
                 'URI'         = $ControlAPITestURI
                 'Method'      = 'GET'
                 'ContentType' = 'application/json'
-                'Credential'  = $Credential
+                'Credential'  = $Credentials
             }
             Write-Debug "Submitting Request to $($RESTRequest.URI)"
 
@@ -175,7 +175,7 @@ function Connect-ControlAPI {
     }
 
     End {
-        If ($SkipCheck -and (!$Server -or ($PSCmdlet.ParameterSetName -eq 'apikey' -and ($Null -eq $APIKey)) -or ($PSCmdlet.ParameterSetName -eq 'credential' -and ($Null -eq $Credential)))) {
+        If ($SkipCheck -and (!$Server -or ($PSCmdlet.ParameterSetName -eq 'apikey' -and ($Null -eq $APIKey)) -or ($PSCmdlet.ParameterSetName -eq 'credential' -and ($Null -eq $Credentials)))) {
             # If Skipping Checks, validate required information exists and throw error if missing.
             Throw "SkipCheck failed because the Server, APIKey, or Credentials were not provided."
             If ($Quiet) {
@@ -194,9 +194,9 @@ function Connect-ControlAPI {
             }
         }
         Else {
-            If ($PSCmdlet.ParameterSetName -eq 'credential' -or ($PSCmdlet.ParameterSetName -eq 'verify' -and $Credential)) {
+            If ($PSCmdlet.ParameterSetName -eq 'credential' -or ($PSCmdlet.ParameterSetName -eq 'verify' -and $Credentials)) {
                 # Set the credentials at the script level
-                $Script:ControlAPICredentials = $Credential
+                $Script:ControlAPICredentials = $Credentials
             } 
             ElseIf ($PSCmdlet.ParameterSetName -eq 'apikey' -or ($PSCmdlet.ParameterSetName -eq 'verify' -and $APIKey)) {
                 $Script:ControlAPIKey = $APIKey

--- a/Public/Connect-ControlAPI.ps1
+++ b/Public/Connect-ControlAPI.ps1
@@ -160,7 +160,7 @@ function Connect-ControlAPI {
 
             # Invoke the REST Request
             Try {
-                $ControlAPITokenResult = Invoke-RestMethod @RESTRequest -SkipCertificateCheck
+                $ControlAPITokenResult = Invoke-RestMethod @RESTRequest
             }
             Catch {
                 # The authentication has failed, so remove the credentials from the script scope and throw an error

--- a/credentials.example.json
+++ b/credentials.example.json
@@ -1,0 +1,13 @@
+{
+    "Automate": {
+        "server": "",
+        "user": "",
+        "password": "",
+        "clientid": ""
+    },
+    "Control": {
+        "server": "",
+        "user": "",
+        "password": ""
+    }
+}


### PR DESCRIPTION
Added Pester tests for automated testing while developing
Added check in the module for powershell version, AutomateAPI.psm1 Add-Type breaks on PS version over 6
Changed -Credential to match example as -Credentials