### PR TITLE
Add 'sh' support to Invoke-AutomateCommand for Mac/Linux machines

### DIFF
--- a/Public/Invoke-AutomateCommand.ps1
+++ b/Public/Invoke-AutomateCommand.ps1
@@ -51,6 +51,7 @@ function Invoke-AutomateCommand {
         [Parameter(ParameterSetName = 'ExecuteCommand')]
         [Parameter(ParameterSetName = 'PassthroughObjects')]
         [switch]$PowerShell,
+        [switch]$sh,
         [Parameter(ParameterSetName = 'CommandID', Mandatory = $True)]
         [int]$CommandID=2,
         [Parameter(ParameterSetName = 'CommandID')]
@@ -78,6 +79,8 @@ function Invoke-AutomateCommand {
             If ($PowerShell) {
                 $Command=$Command -Replace '"','\"'
                 $FormattedCommand="powershell.exe!!! -NonInteractive -Command ""`$WorkingDirectory=[System.Environment]::ExpandEnvironmentVariables('$WorkingDirectory'); Set-Location -Path `$WorkingDirectory -ErrorAction Stop; $Command"""
+            } ElseIf ($sh) {
+                $FormattedCommand="cd / && $Command"
             } Else {
                 $FormattedCommand="cmd.exe!!! /c ""CD /D ""$WorkingDirectory"" && $Command"""
             }


### PR DESCRIPTION
Please add 'sh' support to Invoke-AutomateCommand for Mac/Linux machines in Automate. 

BTW, I love this wrapper! Thank you for all your efforts in creating this.
-Sam